### PR TITLE
feat: content snap generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SNAP_DIRS := $(shell find target -type d -exec test -e {}/snap/snapcraft.yaml \; -print)
+
+all: build
+
+build: $(SNAP_DIRS)
+
+prepare:
+	(cd content-snap-generator && mvn package)
+	java -jar content-snap-generator/target/content-snap-generator-1.0-shaded.jar \
+		-m devpack-for-spring-manifest/supported.yaml \
+		-d target -t content-snaps
+
+$(SNAP_DIRS): prepare
+	@echo "Building snap in $@"
+	cd $@ && snapcraft && snap install *.snap --classic --dangerous
+
+clean:
+	for dir in $(SNAP_DIRS); do \
+		(cd $$dir && snapcraft clean); \
+	done
+
+.PHONY: all install clean $(SNAP_DIRS) *.snap

--- a/content-snap-generator/.springjavaformatconfig
+++ b/content-snap-generator/.springjavaformatconfig
@@ -1,0 +1,1 @@
+indentation-style=spaces

--- a/content-snap-generator/checkstyle/checkstyle-suppressions.xml
+++ b/content-snap-generator/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress checks="SpringHeader" files=".*"/>
+    <suppress checks="JavadocPackage" files=".*"/>
+</suppressions>

--- a/content-snap-generator/pom.xml
+++ b/content-snap-generator/pom.xml
@@ -38,6 +38,11 @@
             <version>2.2</version>
         </dependency>
         <dependency>
+            <groupId>org.tomlj</groupId>
+            <artifactId>tomlj</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.8.0</version>

--- a/content-snap-generator/pom.xml
+++ b/content-snap-generator/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.canonical.devpackspring</groupId>
+    <artifactId>content-snap-generator</artifactId>
+    <version>1.0</version>
+
+    <name>content-snap-generator</name>
+    <url>https://github.com/canonical/devpack-for-spring</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.canonical.devpackspring.content.App</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>9.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.spring.javaformat</groupId>
+                        <artifactId>spring-javaformat-checkstyle</artifactId>
+                        <version>0.0.43</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>checkstyle-validation</id>
+                        <phase>validate</phase>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <configLocation>io/spring/javaformat/checkstyle/checkstyle.xml</configLocation>
+                            <suppressionsLocation>checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/content-snap-generator/src/main/java/com/canonical/devpackspring/content/App.java
+++ b/content-snap-generator/src/main/java/com/canonical/devpackspring/content/App.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of Devpack for Spring® snap.
+ *
+ * Copyright 2025 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.devpackspring.content;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.text.StringSubstitutor;
+import org.yaml.snakeyaml.Yaml;
+
+
+public final class App {
+
+    private static final String CONTENT_SNAPS = "content-snaps";
+    private static final Log LOG = LogFactory.getLog(App.class);
+
+    private App() {
+
+    }
+
+    private static Set<ContentSnap> loadSnaps(String path) throws IOException {
+        Yaml yaml = new Yaml();
+        HashSet<ContentSnap> snapList = new HashSet<ContentSnap>();
+        byte[] manifest = Files.readAllBytes(Path.of(path));
+        try (InputStream is = new ByteArrayInputStream(manifest)) {
+            Map<String, Object> raw = yaml.load(is);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> snaps = (Map<String, Object>) raw.get(CONTENT_SNAPS);
+            if (snaps == null) {
+                throw new IOException("Manifest does not contain 'content-snaps' tag");
+            }
+            for (var name : snaps.keySet()) {
+                @SuppressWarnings("unchecked")
+                var data = (Map<String, Object>) snaps.get(name);
+                if (data.get("tool") instanceof Boolean b && b) {
+                    LOG.info("Skipping " + data.get("name"));
+                    continue;
+                }
+                var snap = (Map<String, String>) snaps.get(name);
+                snapList.add(new ContentSnap(snap.get("name"), snap.get("version"), snap.get("summary"),
+                        snap.get("description"), snap.get("upstream"), snap.get("license"),
+                        snap.getOrDefault("build-jdk", "openjdk-17-jdk-headless"),
+                        snap.getOrDefault("extra-command", "")));
+            }
+        }
+        return snapList;
+    }
+
+    private static void writeContentSnap(ContentSnap snap, Path destination, Path templates) throws IOException {
+        LOG.info("Writing content snap " + snap.name + " version " + snap.version);
+        Path source = templates.resolve(snap.name);
+        if (!source.toFile().exists()) {
+            LOG.info("source " + source + " not found, trying common");
+            source = templates.resolve("common");
+        }
+
+        if (!source.toFile().exists()) {
+            throw new IOException("Common template " + source.toFile() + " does not exist.");
+        }
+
+        final var snapDestination = destination.resolve(snap.name());
+        snapDestination.toFile().mkdirs();
+        final var root = source;
+        final var replacer = new StringSubstitutor(snap.getReplacements());
+        var visitor = new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Path relative = root.relativize(file);
+                Path target = snapDestination.resolve(relative);
+                target.toFile().getParentFile().mkdirs();
+                var fileName = file.toFile().getName();
+                if (fileName.endsWith(".yaml.template")) {
+                    var content = replacer.replace(Files.readString(file));
+                    fileName = fileName.substring(0, fileName.lastIndexOf('.'));
+                    var snapcraftYaml = target.getParent().resolve(fileName);
+                    Files.writeString(snapcraftYaml, content);
+                }
+                else {
+                    LOG.info("Copy from " + file + " to " + target);
+                    Files.copy(file, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+
+        Files.walkFileTree(root, visitor);
+    }
+
+    public static void main(String[] args) throws IOException {
+
+        Options options = new Options();
+        Option installOption = Option.builder("m")
+                .longOpt("manifest")
+                .argName("manifest")
+                .hasArg()
+                .required()
+                .desc("content snap manifest")
+                .build();
+        options.addOption(installOption);
+
+        Option destination = Option.builder("d")
+                .longOpt("destination")
+                .argName("directory")
+                .hasArg()
+                .required(false)
+                .desc("Generate snaps in <destination> directory")
+                .build();
+        options.addOption(destination);
+
+        Option templates = Option.builder("t")
+                .longOpt("template-directory")
+                .argName("directory")
+                .hasArg()
+                .required(true)
+                .desc("Directory with content snap templates")
+                .build();
+        options.addOption(templates);
+
+        CommandLineParser parser = new DefaultParser();
+        try {
+            CommandLine cmd = parser.parse(options, args);
+            if (cmd.hasOption("m")) {
+                String manifest = cmd.getOptionValue("m");
+                Set<ContentSnap> snaps = loadSnaps(manifest);
+                for (ContentSnap snap : snaps) {
+                    writeContentSnap(snap, Path.of(cmd.getOptionValue("d", "content")), Path.of(cmd.getOptionValue("t")));
+                }
+            }
+            else {
+                throw new ParseException("Missing -m, print help");
+            }
+        }
+        catch (ParseException ex) {
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp("generate", options);
+            System.exit(-1);
+        }
+    }
+
+    record ContentSnap(String name, String version, String summary, String description, String upstream, String license,
+                       String build_jdk, String extra_command) {
+
+        public Map<String, String> getReplacements() {
+
+            Map<String, String> map = new HashMap<String, String>();
+            map.put("name", this.name);
+            map.put("version", this.version);
+            map.put("summary", this.summary);
+            map.put("description", multiLineDescription(this.description));
+            map.put("upstream", this.upstream);
+            map.put("license", this.license);
+            map.put("build-jdk", this.build_jdk);
+            map.put("extra-command", this.extra_command);
+            return map;
+        }
+
+        public String multiLineDescription(String str) {
+            StringBuilder output = new StringBuilder();
+            StringTokenizer tk = new StringTokenizer(str, "\n");
+            while (tk.hasMoreTokens()) {
+                output.append("  ").append(tk.nextToken());
+            }
+            return output.toString();
+        }
+
+        @Override
+        public int hashCode() {
+            return this.name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == null) {
+                return false;
+            }
+            if (other instanceof ContentSnap otherSnap) {
+                return this.name.equals(otherSnap.name);
+            }
+            return false;
+        }
+    }
+
+}

--- a/content-snap-generator/src/test/java/com/canonical/devpackspring/content/TestApp.java
+++ b/content-snap-generator/src/test/java/com/canonical/devpackspring/content/TestApp.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Devpack for Spring® snap.
+ *
+ * Copyright 2025 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.devpackspring.content;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+
+public final class TestApp {
+
+    @Test
+    public void testGenerateManifest(@TempDir Path testDir) throws IOException {
+        String manifest = """
+                content-snaps:
+                  content-for-spring-boot-33:
+                    upstream: https://github.com/spring-projects/spring-boot
+                    version: 3.3.2
+                    channel: latest/edge
+                    mount: /maven-repo
+                    oss-eol: 2025-12-31
+                    name: content-for-spring-boot-33
+                    summary:  Rebuild of Spring® Boot Framework sources v3.4.x
+                    description: |
+                      Rebuild of Spring® Boot Framework sources v3.4.x
+
+                      Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
+                    license: Apache-2.0
+                    build-jdk: openjdk-17-jdk-headless
+                    lts: false
+                  
+                  content-for-spring-boot-34:
+                    upstream: https://github.com/spring-projects/spring-boot
+                    version: 3.4.2
+                    channel: latest/edge
+                    mount: /maven-repo
+                    oss-eol: 2025-12-31
+                    name: content-for-spring-boot-34
+                    summary:  Rebuild of Spring® Boot Framework sources v3.4.x
+                    description: |
+                      Rebuild of Spring® Boot Framework sources v3.4.x
+
+                      Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
+                    license: Apache-2.0
+                    build-jdk: openjdk-17-jdk-headless
+                    lts: false
+                """;
+        Path testManifest = testDir.resolve("manifest.yaml");
+        Files.writeString(testManifest, manifest);
+        App.main(new String[]{"-m", testManifest.toString(), "-d", testDir.toString(), "-t", "src/test/resources/com/canonical/devpackspring/content"});
+
+        Path contentSnapPath = testDir.resolve("content-for-spring-boot-34");
+        Path snapcraftYaml = contentSnapPath.resolve("snap/snapcraft.yaml");
+        Path testFile = contentSnapPath.resolve("test.file");
+
+        assertThat(snapcraftYaml.toFile()).exists();
+        assertThat(testFile.toFile()).exists();
+
+        Yaml yaml = new Yaml();
+
+        Map<String, Object> ret = yaml.load(Files.readString(snapcraftYaml));
+        assertThat(ret.get("version")).isEqualTo("3.4.2");
+        assertThat(ret.get("name")).isEqualTo("content-for-spring-boot-34");
+
+        contentSnapPath = testDir.resolve("content-for-spring-boot-33");
+        snapcraftYaml = contentSnapPath.resolve("snap/snapcraft.yaml");
+        assertThat(snapcraftYaml.toFile()).exists();
+        ret = yaml.load(Files.readString(snapcraftYaml));
+        assertThat(ret.get("version")).isEqualTo("3.3.2");
+        assertThat(ret.get("name")).isEqualTo("content-for-spring-boot-33");
+    }
+
+    @Test
+    @Disabled
+    void testBuildSnap(@TempDir Path testDir) throws IOException, InterruptedException {
+        Path contentSnapPath = testDir.resolve("content-for-spring-boot-34");
+        testGenerateManifest(testDir);
+        Process snapcraft = new ProcessBuilder("snapcraft").directory(contentSnapPath.toFile()).inheritIO().start();
+        int ret = snapcraft.waitFor();
+        assertThat(ret).isEqualTo(0);
+        Path builtSnapPath = contentSnapPath.resolve("content-for-spring-boot-34_3.4.2_amd64.snap");
+        assertThat(builtSnapPath.toFile()).exists();
+    }
+
+}

--- a/content-snap-generator/src/test/java/com/canonical/devpackspring/content/TestApp.java
+++ b/content-snap-generator/src/test/java/com/canonical/devpackspring/content/TestApp.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License along with
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.canonical.devpackspring.content;
 
 import java.io.IOException;
@@ -21,21 +22,27 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.yaml.snakeyaml.Yaml;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public final class TestApp {
 
     @Test
     public void testGenerateManifest(@TempDir Path testDir) throws IOException {
+        String versions = """
+                [libraries]
+                spring-boot-34 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.4.2" }
+                spring-boot-33 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.3.2" }
+                """;
         String manifest = """
                 content-snaps:
                   content-for-spring-boot-33:
                     upstream: https://github.com/spring-projects/spring-boot
-                    version: 3.3.2
+                    version: spring-boot-33
                     channel: latest/edge
                     mount: /maven-repo
                     oss-eol: 2025-12-31
@@ -48,10 +55,10 @@ public final class TestApp {
                     license: Apache-2.0
                     build-jdk: openjdk-17-jdk-headless
                     lts: false
-                  
+
                   content-for-spring-boot-34:
                     upstream: https://github.com/spring-projects/spring-boot
-                    version: 3.4.2
+                    version: spring-boot-34
                     channel: latest/edge
                     mount: /maven-repo
                     oss-eol: 2025-12-31
@@ -67,6 +74,8 @@ public final class TestApp {
                 """;
         Path testManifest = testDir.resolve("manifest.yaml");
         Files.writeString(testManifest, manifest);
+        Path testVersions = testDir.resolve("manifest.versions.toml");
+        Files.writeString(testVersions, versions);
         App.main(new String[]{"-m", testManifest.toString(), "-d", testDir.toString(), "-t", "src/test/resources/com/canonical/devpackspring/content"});
 
         Path contentSnapPath = testDir.resolve("content-for-spring-boot-34");

--- a/content-snap-generator/src/test/resources/com/canonical/devpackspring/content/common/snap/snapcraft.yaml.template
+++ b/content-snap-generator/src/test/resources/com/canonical/devpackspring/content/common/snap/snapcraft.yaml.template
@@ -1,0 +1,44 @@
+name: ${name}
+base: bare
+build-base: core24
+version: '${version}'
+summary: ${summary}
+license: ${license}
+description: |
+${description}
+
+grade: devel
+confinement: strict
+
+slots:
+  ${name}:
+    interface: content
+    content: ${name}
+    source:
+      read:
+        - $SNAP
+
+parts:
+  gradle-init:
+    plugin: nil
+    source: .
+    override-build: |
+      cp init.gradle $CRAFT_STAGE/
+
+  content:
+    after:
+      - gradle-init
+    plugin: nil
+    source: ${upstream}
+    source-type: git
+    source-tag: v${version}
+    build-packages:
+      - ${build-jdk}
+    override-build: |
+      echo 127.0.0.1 $(hostname) >> /etc/hosts
+      mkdir -p $HOME/.gradle
+      echo 'systemProp.user.name=spring-builds+github' >> $HOME/.gradle/gradle.properties
+      echo 'systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false' >> $HOME/.gradle/gradle.properties
+      echo 'org.gradle.daemon=false' >> $HOME/.gradle/gradle.properties
+      echo 'org.gradle.daemon=4' >> $HOME/.gradle/gradle.properties
+      ./gradlew -PdeploymentRepository=$CRAFT_PART_INSTALL/maven-repo build publishAllPublicationsToDeploymentRepository ${extra-command}

--- a/content-snap-generator/src/test/resources/com/canonical/devpackspring/content/content-for-spring-boot-34/snap/snapcraft.yaml.template
+++ b/content-snap-generator/src/test/resources/com/canonical/devpackspring/content/content-for-spring-boot-34/snap/snapcraft.yaml.template
@@ -1,0 +1,44 @@
+name: ${name}
+base: bare
+build-base: core24
+version: '${version}'
+summary: ${summary}
+license: ${license}
+description: |
+${description}
+
+grade: devel
+confinement: strict
+
+slots:
+  ${name}:
+    interface: content
+    content: ${name}
+    source:
+      read:
+        - $SNAP
+
+parts:
+  gradle-init:
+    plugin: nil
+    source: .
+    override-build: |
+      cp init.gradle $CRAFT_STAGE/
+
+  content:
+    after:
+      - gradle-init
+    plugin: nil
+    source: ${upstream}
+    source-type: git
+    source-tag: v${version}
+    build-packages:
+      - ${build-jdk}
+    override-build: |
+      echo 127.0.0.1 $(hostname) >> /etc/hosts
+      mkdir -p $HOME/.gradle
+      echo 'systemProp.user.name=spring-builds+github' >> $HOME/.gradle/gradle.properties
+      echo 'systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false' >> $HOME/.gradle/gradle.properties
+      echo 'org.gradle.daemon=false' >> $HOME/.gradle/gradle.properties
+      echo 'org.gradle.daemon=4' >> $HOME/.gradle/gradle.properties
+      ./gradlew -PdeploymentRepository=$CRAFT_PART_INSTALL/maven-repo build publishAllPublicationsToDeploymentRepository ${extra-command}

--- a/content-snap-generator/src/test/resources/com/canonical/devpackspring/content/content-for-spring-boot-34/test.file
+++ b/content-snap-generator/src/test/resources/com/canonical/devpackspring/content/content-for-spring-boot-34/test.file
@@ -1,0 +1,1 @@
+test.file

--- a/content-snaps/common/snap/snapcraft.yaml.template
+++ b/content-snaps/common/snap/snapcraft.yaml.template
@@ -1,0 +1,44 @@
+name: ${name}
+base: bare
+build-base: core24
+version: '${version}'
+summary: ${summary}
+license: ${license}
+description: |
+${description}
+
+grade: devel
+confinement: strict
+
+slots:
+  ${name}:
+    interface: content
+    content: ${name}
+    source:
+      read:
+        - $SNAP
+
+parts:
+  gradle-init:
+    plugin: nil
+    source: .
+    override-build: |
+      cp init.gradle $CRAFT_STAGE/
+
+  content:
+    after:
+      - gradle-init
+    plugin: nil
+    source: ${upstream}
+    source-type: git
+    source-tag: v${version}
+    build-packages:
+      - ${build-jdk}
+    override-build: |
+      echo 127.0.0.1 $(hostname) >> /etc/hosts
+      mkdir -p $HOME/.gradle
+      echo 'systemProp.user.name=spring-builds+github' >> $HOME/.gradle/gradle.properties
+      echo 'systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false' >> $HOME/.gradle/gradle.properties
+      echo 'org.gradle.daemon=false' >> $HOME/.gradle/gradle.properties
+      echo 'org.gradle.daemon=4' >> $HOME/.gradle/gradle.properties
+      ./gradlew -PdeploymentRepository=$CRAFT_PART_INSTALL/maven-repo build publishAllPublicationsToDeploymentRepository ${extra-command}

--- a/content-snaps/common/snap/snapcraft.yaml.template
+++ b/content-snaps/common/snap/snapcraft.yaml.template
@@ -19,15 +19,7 @@ slots:
         - $SNAP
 
 parts:
-  gradle-init:
-    plugin: nil
-    source: .
-    override-build: |
-      cp init.gradle $CRAFT_STAGE/
-
   content:
-    after:
-      - gradle-init
     plugin: nil
     source: ${upstream}
     source-type: git

--- a/devpack-for-spring-manifest/generate-manifest.py
+++ b/devpack-for-spring-manifest/generate-manifest.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import yaml
+import toml
+
+with open("supported.yaml", "r") as yaml_file:
+    yaml_data = yaml.safe_load(yaml_file)
+
+with open("supported.versions.toml", "r") as toml_file:
+    toml_data = toml.load(toml_file)
+
+def set_versions(yaml_data, toml_data):
+    libraries = toml_data['libraries']
+    snaps = yaml_data['content-snaps']
+    for _, description in snaps.items():
+        description['version'] = libraries[description['version']]['version']
+
+set_versions(yaml_data, toml_data)
+
+with open("transformed.yaml", "w") as yaml_file:
+    yaml.safe_dump(yaml_data, yaml_file)

--- a/devpack-for-spring-manifest/snap/snapcraft.yaml
+++ b/devpack-for-spring-manifest/snap/snapcraft.yaml
@@ -29,9 +29,12 @@ parts:
       - git
       - yamllint
       - yq
+      - python3
     override-build: |
-      craftctl default
       yamllint supported.yaml
+      ./generate-manifest.py
+      mv transformed.yaml supported.yaml
+      craftctl default
       craftctl set version="$(yq .version supported.yaml)"
     prime:
       - supported.yaml

--- a/devpack-for-spring-manifest/supported.versions.toml
+++ b/devpack-for-spring-manifest/supported.versions.toml
@@ -1,0 +1,7 @@
+
+
+[libraries]
+spring-boot-34 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.4.2" }
+spring-boot-33 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.3.8" }
+spring-core-61 = { group = "org.springframework", name = "spring-core", version = "6.1.0" }
+spring-core-62 = { group = "org.springframework", name = "spring-core", version = "6.2.0" }

--- a/devpack-for-spring-manifest/supported.versions.toml
+++ b/devpack-for-spring-manifest/supported.versions.toml
@@ -1,5 +1,3 @@
-
-
 [libraries]
 spring-boot-34 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.4.2" }
 spring-boot-33 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.3.8" }

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -1,24 +1,8 @@
 version: 1
 content-snaps:
-  content-for-spring-cli:
-    upstream: https://github.com/spring-projects/spring-cli
-    version: 0.9.0
-    channel: latest/edge
-    mount: /spring-cli
-    oss-eol: n/a
-    name: content-for-spring-cli
-    build-jdk: openjdk-17-jdk-headless
-    summary: Rebuild of Spring® CLI sources
-    description: |
-      Rebuild of Spring® CLI sources.
-      Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
-    license: Apache-2.0
-    lts: false
-    tool: true
-
   content-for-spring-boot-34:
     upstream: https://github.com/spring-projects/spring-boot
-    version: 3.4.2
+    version: spring-boot-34
     channel: latest/edge
     mount: /maven-repo
     oss-eol: 2025-12-31
@@ -33,7 +17,7 @@ content-snaps:
 
   content-for-spring-boot-runtime-33:
     upstream: https://github.com/spring-projects/spring-boot
-    version: 3.3.8
+    version: spring-boot-33
     channel: latest/edge
     mount: /maven-repo
     oss-eol: 2025-06-30
@@ -48,7 +32,7 @@ content-snaps:
 
   content-for-spring-framework-62:
     upstream: https://github.com/spring-projects/spring-framework
-    version: 6.2.3
+    version: spring-core-62
     channel: latest/edge
     mount: /maven-repo
     oss-eol: 2026-06-30
@@ -63,7 +47,7 @@ content-snaps:
 
   content-for-spring-framework-61:
     upstream: https://github.com/spring-projects/spring-framework
-    version: 6.1.14
+    version: spring-core-61
     channel: latest/edge
     mount: /maven-repo
     oss-eol: 2026-06-30

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "branchConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "packageRules": [
+    {
+        "matchFileNames": ["devpack-for-spring-manifest/supported.versions.toml"],
+        "groupName": "content snap version updates",
+        "separateMinorPatch": true,
+        "separateMajorMinor": true
+    },
+    {
+        "matchFileNames": ["devpack-for-spring-manifest/supported.versions.toml"],
+        "matchUpdateTypes": ["major", "minor"],
+        "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The content snaps are generated from the manifest and templates located in content-snaps/. 
If there is no template with the snap's name, e.g. `content-snaps/content-for-spring-boot-34`, then the generator will use template in `content-snap/common`. 
The generator will fill in values from the manifest in the template and write the content snaps into destination directory. 

The versions of the content snaps are stored in gradle version catalog `supported.version.toml`. Renovate bot is configured to update the versions there.

Remaining PR - add github publishing pipeline after this one.