### PR TITLE
fix: do not overwrite source files

### DIFF
--- a/devpack-for-spring-manifest/generate-manifest.py
+++ b/devpack-for-spring-manifest/generate-manifest.py
@@ -2,11 +2,12 @@
 
 import yaml
 import toml
+import sys
 
-with open("supported.yaml", "r") as yaml_file:
+with open(sys.argv[1], "r") as yaml_file:
     yaml_data = yaml.safe_load(yaml_file)
 
-with open("supported.versions.toml", "r") as toml_file:
+with open(sys.argv[2], "r") as toml_file:
     toml_data = toml.load(toml_file)
 
 def set_versions(yaml_data, toml_data):
@@ -17,5 +18,5 @@ def set_versions(yaml_data, toml_data):
 
 set_versions(yaml_data, toml_data)
 
-with open("transformed.yaml", "w") as yaml_file:
+with open(sys.argv[3], "w") as yaml_file:
     yaml.safe_dump(yaml_data, yaml_file)

--- a/devpack-for-spring-manifest/snap/snapcraft.yaml
+++ b/devpack-for-spring-manifest/snap/snapcraft.yaml
@@ -23,7 +23,7 @@ slots:
 
 parts:
   devpack-for-spring-manifest:
-    plugin: dump
+    plugin: nil
     source: .
     build-packages:
       - git
@@ -32,10 +32,8 @@ parts:
       - python3
     override-build: |
       yamllint supported.yaml
-      ./generate-manifest.py
-      mv transformed.yaml supported.yaml
-      craftctl default
+      ./generate-manifest.py supported.yaml supported.versions.toml \
+        ${CRAFT_PART_INSTALL}/supported.yaml
+      cp LICENSE ${CRAFT_PART_INSTALL}/
       craftctl set version="$(yq .version supported.yaml)"
-    prime:
-      - supported.yaml
-      - LICENSE
+      craftctl default


### PR DESCRIPTION
Snapcraft does not restore source directory and any modification is persisted across the builds.

The old code was modifying supported.yaml causing the build failure on the second run.

This version writes the output into CRAFT_PART_INSTALL

I have raised https://github.com/canonical/craft-parts/issues/1026 for craft-parts