### PR TITLE
fix: remove allow-auto-connection tag

### DIFF
--- a/devpack-for-spring-manifest/snap/snapcraft.yaml
+++ b/devpack-for-spring-manifest/snap/snapcraft.yaml
@@ -10,14 +10,6 @@ description: |
 grade: stable
 confinement: strict
 
-slots:
-  devpack-for-spring-manifest:
-    interface: content
-    content: devpack-for-spring-manifest
-    source:
-      read:
-        - $SNAP
-
 parts:
   devpack-for-spring-manifest:
     plugin: nil

--- a/devpack-for-spring-manifest/snap/snapcraft.yaml
+++ b/devpack-for-spring-manifest/snap/snapcraft.yaml
@@ -14,9 +14,6 @@ slots:
   devpack-for-spring-manifest:
     interface: content
     content: devpack-for-spring-manifest
-    allow-auto-connection:
-      plug-publisher-id:
-        - $SLOT_PUBLISHER_ID
     source:
       read:
         - $SNAP

--- a/devpack-for-spring/snap/hooks/connect-plug-devpack-for-spring-content
+++ b/devpack-for-spring/snap/hooks/connect-plug-devpack-for-spring-content
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -euxo pipefail
-
-devpack-for-spring snap setup-gradle
-devpack-for-spring snap setup-maven

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -17,17 +17,6 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: classic # use 'strict' once you have the right plugs and slots
 
-plugs:
-  devpack-for-spring-content:
-    interface: content
-    content: devpack-for-spring-content
-    target: $SNAP/maven-repo
-
-  devpack-for-spring-manifest:
-    interface: content
-    content: devpack-for-spring-content
-    target: $SNAP/manifest
-
 parts:
   build-cli:
     plugin: nil


### PR DESCRIPTION
The tag caused the failure to upload to snap store:
```
Issues while processing snap:
- Error found while validating snap.json::$.slots.devpack-for-spring-manifest: Additional properties are not allowed ('allow-auto-connection' was unexpected)
Full execution log: '/home/runner/.local/state/snapcraft/log/snapcraft-[20](https://github.com/canonical/devpack-for-spring/actions/runs/13583625478/job/37974126673#step:4:21)250228-075209.754925.log'
```