### PR TITLE
fix: add missing dependencies

### DIFF
--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ parts:
   build-cli:
     plugin: nil
     source: https://github.com/canonical/spring-cli
+    source-tag: v0.10.0-c1
     source-type: git
     build-packages:
       - openjdk-17-jdk-headless

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '0.10'
+version: '0.11'
 summary: Development tools for Spring® projects
 description: |
   Development tools for Spring® projects.
@@ -47,6 +47,11 @@ parts:
       - enable-patchelf
     stage-packages:
       - openjdk-21-jdk-headless
+      - libc6
+      - libgcc-s1
+      - libstdc++6
+      - zlib1g
+      - libnss3
     override-build: |
       craftctl default
       (cd $CRAFT_PART_INSTALL && mkdir -p usr/bin && ln -sf --relative usr/lib/jvm/java-21-openjdk-${CRAFT_ARCH_BUILD_FOR}/bin/java usr/bin/java)


### PR DESCRIPTION
- bump version of the snap
- tag spring-cli release
-  fix https://github.com/canonical/devpack-for-spring/issues/23

stage-packages only adds the package content, it does not add the dependencies. 
Explicitly list dependencies to stage.

Testing:

```
$ devpack-for-spring 
spring:>exit
```

```
$ldd /snap/devpack-for-spring/current/usr/lib/jvm/java-21-openjdk-amd64/bin/java
	linux-vdso.so.1 (0x00007ffd6ef7a000)
	libz.so.1 => /snap/devpack-for-spring/current/usr/lib/jvm/java-21-openjdk-amd64/bin/../../../x86_64-linux-gnu/libz.so.1 (0x00007f44eff95000)
	libjli.so => /snap/devpack-for-spring/current/usr/lib/jvm/java-21-openjdk-amd64/bin/../lib/libjli.so (0x00007f44eff83000)
	libc.so.6 => /snap/devpack-for-spring/current/usr/lib/jvm/java-21-openjdk-amd64/bin/../../../x86_64-linux-gnu/libc.so.6 (0x00007f44efd70000)
	/snap/devpack-for-spring/current/usr/lib64/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f44effbb000)

```