### PR TITLE
fix: add configure hook for devpack-for-spring-manifest

### DIFF
--- a/devpack-for-spring-manifest/snap/snapcraft.yaml
+++ b/devpack-for-spring-manifest/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: devpack-for-spring-manifest
-base: core24
-version: 1.0
+build-base: core24
+base: bare
 adopt-info: devpack-for-spring-manifest
 summary: The list of all available content snaps for Spring®
 description: |

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 content-snaps:
   content-for-spring-boot-35:
     upstream: https://github.com/spring-projects/spring-boot

--- a/devpack-for-spring/snap/hooks/configure
+++ b/devpack-for-spring/snap/hooks/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ ! -f /snap/devpack-for-spring-manifest/current/supported.yaml ]; then
+    snap install devpack-for-spring-manifest --edge
+else
+    snap refresh devpack-for-spring-manifest --edge
+fi


### PR DESCRIPTION
- use `base: bare` to avoid installing core24 snap
- add configure hook to devpack-for-spring to install manifest automatically
- bump manifest version