### PR TITLE
feat: add spread tests for devpack-for-spring

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, large, jammy, X64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           path: ${{ steps.devpack-for-spring-manifest.outputs.snap }}
 
   snap-tests:
-    runs-on: [self-hosted, spread-installed]
+    runs-on: [self-hosted, large, jammy, X64]
     needs: [snap-build]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - name: Checkout rockcraft
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -63,8 +63,24 @@ jobs:
           name: devpack-for-spring
           path: devpack-for-spring
 
+      - uses: actions/checkout@v4
+        with:
+          repository: snapcore/spread
+          path: _spread
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Install LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+            channel: 5.21/stable
+
       - name: Run spread
-        run: spread
+        run: |
+          (cd _spread/cmd/spread && go build)
+          _spread/cmd/spread/spread
 
       - name: Discard spread workers
         if: always()

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -1,0 +1,75 @@
+name: Spread
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  snap-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build devpack
+        id: devpack-for-spring
+        uses: snapcore/action-build@v1
+        with:
+          path: devpack-for-spring
+      - name: Upload Snap to workflow artifacts
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devpack-for-spring
+          path: ${{ steps.devpack-for-spring.outputs.snap }}
+      - name: Build manifest
+        id: devpack-for-spring-manifest
+        uses: snapcore/action-build@v1
+        with:
+          path: devpack-for-spring-manifest
+      - name: Upload Snap to workflow artifacts
+        id: upload-artifact-manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: devpack-for-spring-manifest
+          path: ${{ steps.devpack-for-spring-manifest.outputs.snap }}
+
+  snap-tests:
+    runs-on: [self-hosted, spread-installed]
+    needs: [snap-build]
+
+    steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+      - name: Checkout rockcraft
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devpack-for-spring-manifest
+          path: devpack-for-spring-manifest
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devpack-for-spring
+          path: devpack-for-spring
+
+      - name: Run spread
+        run: spread
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done

--- a/run-spread.sh
+++ b/run-spread.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+find . -name *.snap -delete
 make prepare
 (cd devpack-for-spring-manifest && snapcraft)
 (cd devpack-for-spring && snapcraft)

--- a/run-spread.sh
+++ b/run-spread.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+make prepare
+(cd devpack-for-spring-manifest && snapcraft)
+(cd devpack-for-spring && snapcraft)
+spread $*

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,15 @@
+project: devpack-for-spring
+
+backends:
+  lxd:
+    systems:
+      - ubuntu-24.04
+
+path: /home/test
+
+suites:
+  tests/spread/:
+    summary: integration tests
+
+prepare: |
+  find . -name *.snap -exec snap install --dangerous --classic {} \;

--- a/spread.yaml
+++ b/spread.yaml
@@ -4,6 +4,8 @@ backends:
   lxd:
     systems:
       - ubuntu-24.04
+      - ubuntu-22.04
+      - ubuntu-20.04
 
 path: /home/test
 
@@ -12,4 +14,10 @@ suites:
     summary: integration tests
 
 prepare: |
-  find . -name *.snap -exec snap install --dangerous --classic {} \;
+  set -ex
+  # install local devpack
+  find devpack-for-spring -name *.snap -exec snap install --dangerous --classic {} \;
+  # check that it pulled manifest from the snap store
+  snap info devpack-for-spring-manifest | grep "installed:"
+  # install local manifest
+  find devpack-for-spring-manifest -name *.snap -exec snap install --dangerous --classic {} \;

--- a/tests/spread/install-content/task.yaml
+++ b/tests/spread/install-content/task.yaml
@@ -2,8 +2,17 @@ summary: check that devpack for spring can install content snaps
 
 execute: |
   set -ex
-  SNAPS=`devpack-for-spring snap list | grep content | awk -F'│' '{ print $3}'`
+  SNAPS=`devpack-for-spring snap list | grep content | awk -F'│' '{ print $3 }'`
   for snap in $SNAPS; do
+    # install snap
     devpack-for-spring snap install $snap
+    devpack-for-spring snap list | grep $snap | grep '✓'
+    # regenerate configuration
+    devpack-for-spring snap setup-gradle
+    devpack-for-spring snap setup-maven
+    # remove snap
     devpack-for-spring snap remove $snap
+    # regenerate configuration
+    devpack-for-spring snap setup-gradle
+    devpack-for-spring snap setup-maven
   done

--- a/tests/spread/install-content/task.yaml
+++ b/tests/spread/install-content/task.yaml
@@ -1,0 +1,9 @@
+summary: check that devpack for spring can install content snaps
+
+execute: |
+  set -ex
+  SNAPS=`devpack-for-spring snap list | grep content | awk -F'│' '{ print $3}'`
+  for snap in $SNAPS; do
+    devpack-for-spring snap install $snap
+    devpack-for-spring snap remove $snap
+  done

--- a/tests/spread/project-build-gradle/task.yaml
+++ b/tests/spread/project-build-gradle/task.yaml
@@ -1,0 +1,16 @@
+summary: check that Gradle uses content snap
+
+execute: |
+  set -ex
+  # use snap-provided JVM
+  export PATH=$PATH:/snap/devpack-for-spring/current/usr/bin/
+  devpack-for-spring snap install content-for-spring-boot-35
+  BOOT_VERSION=`snap info  content-for-spring-boot-35 | grep "installed:" | awk -F' ' '{ print $2}'`
+  devpack-for-spring boot start --path foo --project gradle-project \
+   --language java --boot-version $BOOT_VERSION --group sample \
+   --artifact sample --name sample --description sample \
+   --package-name sample --packaging jar \
+   --java-version 17 --version 1 --dependencies web
+  (cd foo && ./gradlew --debug > debug.log 2>&1)
+  # We should be using the local repository for gradle
+  grep "Using org.springframework.boot:spring-boot-loader-tools:${BOOT_VERSION} from Maven repository 'plugin-content-for-spring-boot-35'" foo/debug.log

--- a/tests/spread/project-build-maven/task.yaml
+++ b/tests/spread/project-build-maven/task.yaml
@@ -1,0 +1,16 @@
+summary: check that Maven uses the content snap
+
+execute: |
+  set -ex
+  # use snap-provided JVM
+  export PATH=$PATH:/snap/devpack-for-spring/current/usr/bin/
+  devpack-for-spring snap install content-for-spring-boot-35
+  BOOT_VERSION=`snap info  content-for-spring-boot-35 | grep "installed:" | awk -F' ' '{ print $2}'`
+  devpack-for-spring boot start --path foo --project maven-project \
+   --language java --boot-version $BOOT_VERSION --group sample \
+   --artifact sample --name sample --description sample \
+   --package-name sample --packaging jar \
+   --java-version 17 --version 1 --dependencies web
+  (cd foo && ./mvnw package --debug > debug.log 2>&1)
+  # We should be using the local repository for maven
+  grep "Downloading from content-for-spring-boot-35-plugins: file:///snap/content-for-spring-boot-35/current/maven-repo/org/springframework/boot/spring-boot-maven-plugin/${BOOT_VERSION}/spring-boot-maven-plugin-${BOOT_VERSION}.jar" foo/debug.log

--- a/tests/spread/smoke/task.yaml
+++ b/tests/spread/smoke/task.yaml
@@ -2,4 +2,4 @@ summary: check that devpack for spring works when installed
 
 execute: |
   set -ex
-  devpack-for-spring | grep Devpack
+  devpack-for-spring --help | grep Devpack

--- a/tests/spread/smoke/task.yaml
+++ b/tests/spread/smoke/task.yaml
@@ -1,0 +1,5 @@
+summary: check that devpack for spring works when installed
+
+execute: |
+  set -ex
+  devpack-for-spring | grep Devpack


### PR DESCRIPTION
Add basic smoke tests for the snap functionality:
 - Devpack command group is present
 - All declared content snaps can be installed and removed
 - setup-gradle/setup-maven commands complete successfully
 - maven/gradle projects can be built and use content snap