### PR TITLE
doc: top level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+## devpack-for-spring 
+
+This repository contains [devpack-for-spring](./devpack-for-spring) snap and associated snaps. Please head to [devpack-for-spring](./devpack-for-spring) for the snap documentation.
+


### PR DESCRIPTION
Add the top-level readme to redirect users to the snap documentation