### PR TITLE
chore: add license tags to devpack-for-spring

### DIFF
--- a/devpack-for-spring-manifest/snap/snapcraft.yaml
+++ b/devpack-for-spring-manifest/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: devpack-for-spring-manifest
 build-base: core24
 base: bare
+license: Apache-2.0
 adopt-info: devpack-for-spring-manifest
 summary: The list of all available content snaps for Spring®
 description: |

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -2,6 +2,7 @@ name: devpack-for-spring
 base: bare
 build-base: core24
 version: '1.0.0'
+license: Apache-2.0
 summary: Development tools for Spring® projects
 description: |
   Development tools for Spring® projects.


### PR DESCRIPTION
Adds license tag to devpack-for-spring and devpack-for-spring-manifest.