### PR TITLE
chore: bump versions for build-plugins and spring-cli

### DIFF
--- a/devpack-for-spring/build-plugins.yaml
+++ b/devpack-for-spring/build-plugins.yaml
@@ -19,8 +19,8 @@ format:
 dependencies:
   gradle:
     id: io.github.rockcrafters.rockcraft
-    version: 1.1.0
-    classpath: "io.github.rockcrafters.rockcraft:io.github.rockcrafters.rockcraft.gradle.plugin:1.1.0"
+    version: 1.1.1
+    classpath: "io.github.rockcrafters.rockcraft:io.github.rockcrafters.rockcraft.gradle.plugin:1.1.1"
     class-name: com.canonical.rockcraft.gradle.RockcraftPlugin
     repository: gradlePluginPortal()
     default-task: dependencies-export
@@ -32,7 +32,7 @@ dependencies:
     default-configuration:
   maven:
     id: io.github.rockcrafters:rockcraft-maven-plugin
-    version: 1.1.0
+    version: 1.1.1
     default-task: :create-build-rock
     description: |
       Save project dependencies
@@ -41,8 +41,8 @@ dependencies:
 rockcraft:
   gradle:
     id: io.github.rockcrafters.rockcraft
-    version: 1.1.0
-    classpath: "io.github.rockcrafters.rockcraft:io.github.rockcrafters.rockcraft.gradle.plugin:1.1.0"
+    version: 1.1.1
+    classpath: "io.github.rockcrafters.rockcraft:io.github.rockcrafters.rockcraft.gradle.plugin:1.1.1"
     class-name: com.canonical.rockcraft.gradle.RockcraftPlugin
     repository: gradlePluginPortal()
     default-task: build-rock
@@ -62,7 +62,7 @@ rockcraft:
           }
   maven:
     id: io.github.rockcrafters:rockcraft-maven-plugin
-    version: 1.1.0
+    version: 1.1.1
     default-task: install :create-rock :build-rock
     description: |
       Plugin for rock image generation

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '1.0.0'
+version: '1.0.1'
 license: Apache-2.0
 summary: Development tools for Spring® projects
 description: |

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ parts:
   build-cli:
     plugin: nil
     source: https://github.com/canonical/spring-cli
-    source-tag: v0.10.0-c2.2
+    source-tag: v0.10.0-c2.3
     source-type: git
     build-packages:
       - openjdk-17-jdk-headless


### PR DESCRIPTION
Use java-rockcraft-plujgin 1.1.1 to use jlink plugin in generated rockcraft.yaml
Use spring-cli v0.10.0-c2.3 to fix snap removal message and set gradle timeout