### PR TITLE
fix: rollback upgrade to checkstyle plugin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,9 @@ jobs:
 
       - name: Run content snap generator
         id: gen-content
-        run: make prepare
+        run: |
+          sudo apt-get update && sudo apt-get install -y make maven openjdk-21-jdk-headless
+          make prepare
 
       - name: Build devpack
         id: devpack-for-spring

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/checkout@v4
         id: checkout
 
+      - name: Run content snap generator
+        id: gen-content
+        run: make prepare
+
       - name: Build devpack
         id: devpack-for-spring
         uses: snapcore/action-build@v1

--- a/content-snap-generator/pom.xml
+++ b/content-snap-generator/pom.xml
@@ -91,7 +91,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.23.0</version>
+                        <version>10.21.0</version>
                     </dependency>
                     <dependency>
                         <groupId>io.spring.javaformat</groupId>


### PR DESCRIPTION
spring-javaformat-checkstyle 0.0.43 needs checkstyle 10.21.0. It does not work with .22 and up.