### PR TITLE
feat: allow installing multiple openjdk

### DIFF
--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -51,11 +51,6 @@ jobs:
               distribution: 'temurin'
               java-version: '21'
               cache: 'maven'
-        - uses: actions/setup-java@v4
-          with:
-              distribution: 'temurin'
-              java-version: '24'
-              cache: 'maven'
         - run: |
             sudo apt-get update && sudo apt-get install -y make maven openjdk-21-jdk-headless
             make prepare

--- a/content-snaps/common/snap/snapcraft.yaml.template
+++ b/content-snaps/common/snap/snapcraft.yaml.template
@@ -24,8 +24,7 @@ parts:
     source: ${upstream}
     source-type: git
     source-tag: v${version}
-    build-packages:
-      - ${build-jdk}
+    build-packages: ${build-jdk}
     override-build: |
       echo 127.0.0.1 $(hostname) >> /etc/hosts
       mkdir -p $HOME/.gradle

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -7,7 +7,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2026-06-30
     name: content-for-spring-boot-35
-    build-jdk: openjdk-17-jdk-headless
+    build-jdk: [ "openjdk-17-jdk-headless" ]
     summary: Rebuild of Spring® Boot Framework sources v3.5.x
     description: |
       Rebuild of Spring® Boot Framework sources v3.5.x
@@ -22,7 +22,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2025-12-31
     name: content-for-spring-boot-34
-    build-jdk: openjdk-17-jdk-headless
+    build-jdk: [ "openjdk-17-jdk-headless" ]
     summary: Rebuild of Spring® Boot Framework sources v3.4.x
     description: |
       Rebuild of Spring® Boot Framework sources v3.4.x
@@ -37,7 +37,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2025-06-30
     name: content-for-spring-boot-runtime-33
-    build-jdk: openjdk-17-jdk-headless
+    build-jdk: [ "openjdk-17-jdk-headless" ]
     summary: Rebuild of Spring® Boot Framework sources v3.3.x
     description: |
       Rebuild of Spring® Boot Framework sources v3.3.x
@@ -53,7 +53,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: n/a
     name: content-for-spring-framework-70
-    build-jdk: openjdk-24-jdk
+    build-jdk: [ "openjdk-21-jdk", "openjdk-24-jdk" ]
     summary: Rebuild of Spring® Framework sources v7.0.x
     description: |
       Rebuild of Spring® Framework sources v7.0.x.
@@ -68,7 +68,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2026-06-30
     name: content-for-spring-framework-62
-    build-jdk: openjdk-17-jdk
+    build-jdk: [ "openjdk-17-jdk", "openjdk-21-jdk" ]
     summary: Rebuild of Spring® Framework sources v6.2.x
     description: |
       Rebuild of Spring® Framework sources v6.2.x.
@@ -83,7 +83,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2026-06-30
     name: content-for-spring-framework-61
-    build-jdk: openjdk-17-jdk
+    build-jdk: [ "openjdk-17-jdk", "openjdk-21-jdk" ]
     summary: Rebuild of Spring® Framework sources v6.1.x
     description: |
       Rebuild of Spring® Framework sources v6.1.x.

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -7,7 +7,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2026-06-30
     name: content-for-spring-boot-35
-    build-jdk: [ "openjdk-17-jdk-headless" ]
+    build-jdk: ["openjdk-17-jdk-headless"]
     summary: Rebuild of Spring® Boot Framework sources v3.5.x
     description: |
       Rebuild of Spring® Boot Framework sources v3.5.x
@@ -22,7 +22,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2025-12-31
     name: content-for-spring-boot-34
-    build-jdk: [ "openjdk-17-jdk-headless" ]
+    build-jdk: ["openjdk-17-jdk-headless"]
     summary: Rebuild of Spring® Boot Framework sources v3.4.x
     description: |
       Rebuild of Spring® Boot Framework sources v3.4.x
@@ -37,7 +37,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2025-06-30
     name: content-for-spring-boot-runtime-33
-    build-jdk: [ "openjdk-17-jdk-headless" ]
+    build-jdk: ["openjdk-17-jdk-headless"]
     summary: Rebuild of Spring® Boot Framework sources v3.3.x
     description: |
       Rebuild of Spring® Boot Framework sources v3.3.x
@@ -53,7 +53,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: n/a
     name: content-for-spring-framework-70
-    build-jdk: [ "openjdk-21-jdk", "openjdk-24-jdk" ]
+    build-jdk: ["openjdk-21-jdk", "openjdk-24-jdk"]
     summary: Rebuild of Spring® Framework sources v7.0.x
     description: |
       Rebuild of Spring® Framework sources v7.0.x.
@@ -68,7 +68,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2026-06-30
     name: content-for-spring-framework-62
-    build-jdk: [ "openjdk-17-jdk", "openjdk-21-jdk" ]
+    build-jdk: ["openjdk-17-jdk", "openjdk-21-jdk"]
     summary: Rebuild of Spring® Framework sources v6.2.x
     description: |
       Rebuild of Spring® Framework sources v6.2.x.
@@ -83,7 +83,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: 2026-06-30
     name: content-for-spring-framework-61
-    build-jdk: [ "openjdk-17-jdk", "openjdk-21-jdk" ]
+    build-jdk: ["openjdk-17-jdk", "openjdk-21-jdk"]
     summary: Rebuild of Spring® Framework sources v6.1.x
     description: |
       Rebuild of Spring® Framework sources v6.1.x.


### PR DESCRIPTION
Spring Project uses multiple openjdk in integration tests. 

Latest Spring Core release disabled Gradle auto provisioning. https://github.com/spring-projects/spring-framework/commit/40058ef875318d7b661315588fc61f49fe50d41e
This highlighted the fact that Gradle was downloading additional BellSoft JDK for Java 17 compatibility testing.

This MR allows to configure multiple OpenJDK in snap configuration.