### PR TITLE
fix: do not hardcode jdk vendor in toolchain requirements

### DIFF
--- a/content-snaps/common/snap/snapcraft.yaml.template
+++ b/content-snaps/common/snap/snapcraft.yaml.template
@@ -32,4 +32,6 @@ parts:
       echo 'systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false' >> $HOME/.gradle/gradle.properties
       echo 'org.gradle.daemon=false' >> $HOME/.gradle/gradle.properties
       echo 'org.gradle.daemon=4' >> $HOME/.gradle/gradle.properties
+      # do not hardcode toolchain vendor
+      find . -name JavaConventions.java -exec sed -i 's/toolchain.getVendor().set(JvmVendorSpec.BELLSOFT);//g' {} \;
       ./gradlew -PdeploymentRepository=$CRAFT_PART_INSTALL/maven-repo build publishAllPublicationsToDeploymentRepository ${extra-command}


### PR DESCRIPTION
This depends on https://github.com/canonical/devpack-for-spring/pull/71
