### PR TITLE
chore: revert spring framework 7.0.0-M6 release

### DIFF
--- a/devpack-for-spring-manifest/supported.versions.toml
+++ b/devpack-for-spring-manifest/supported.versions.toml
@@ -4,4 +4,4 @@ spring-boot-34 = { group = "org.springframework.boot", name = "spring-boot-depen
 spring-boot-33 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.3.12" }
 spring-core-61 = { group = "org.springframework", name = "spring-core", version = "6.1.21" }
 spring-core-62 = { group = "org.springframework", name = "spring-core", version = "6.2.8" }
-spring-core-70 = { group = "org.springframework", name = "spring-core", version = "7.0.0-M6" }
+spring-core-70 = { group = "org.springframework", name = "spring-core", version = "7.0.0-M5" }

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -53,7 +53,7 @@ content-snaps:
     mount: /maven-repo
     oss-eol: n/a
     name: content-for-spring-framework-70
-    build-jdk: ["openjdk-21-jdk", "openjdk-24-jdk"]
+    build-jdk: ["openjdk-21-jdk"]
     summary: Rebuild of Spring® Framework sources v7.0.x
     description: |
       Rebuild of Spring® Framework sources v7.0.x.


### PR DESCRIPTION
- auto provisioning is disabled in gradle
- m6 requires openjdk-24
- openjdk-24 is not backported to noble