### PR TITLE
fix: workaround unused import checkstyle error

### DIFF
--- a/content-snaps/common/snap/snapcraft.yaml.template
+++ b/content-snaps/common/snap/snapcraft.yaml.template
@@ -33,5 +33,5 @@ parts:
       echo 'org.gradle.daemon=false' >> $HOME/.gradle/gradle.properties
       echo 'org.gradle.daemon=4' >> $HOME/.gradle/gradle.properties
       # do not hardcode toolchain vendor
-      find . -name JavaConventions.java -exec sed -i 's/toolchain.getVendor().set(JvmVendorSpec.BELLSOFT);//g' {} \;
+      find . -name JavaConventions.java -exec sed -i 's/toolchain.getVendor().set(JvmVendorSpec.BELLSOFT);/System.out.println(JvmVendorSpec.BELLSOFT);/g' {} \;
       ./gradlew -PdeploymentRepository=$CRAFT_PART_INSTALL/maven-repo build publishAllPublicationsToDeploymentRepository ${extra-command}


### PR DESCRIPTION
Checkstyle fails build on unused import after toolchain requirement is removed.  I can not remove import with sed (due to empty line checkstyle error) and do not want to introduce patches as this change will be dropped in the next point release of Spring Libraries.