### PR TITLE
chore: exclude framework api docs from building

### DIFF
--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -60,6 +60,7 @@ content-snaps:
       Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
     license: Apache-2.0
     lts: true
+    extra-command: -x :framework-api:javadoc
 
   content-for-spring-framework-62:
     upstream: https://github.com/spring-projects/spring-framework


### PR DESCRIPTION
spring framework 7.0.0-M5 API docs fail to build.