### PR TITLE
chore: rollback Spring Framework RC to M5.

### DIFF
--- a/devpack-for-spring-manifest/supported.versions.toml
+++ b/devpack-for-spring-manifest/supported.versions.toml
@@ -4,4 +4,4 @@ spring-boot-34 = { group = "org.springframework.boot", name = "spring-boot-depen
 spring-boot-33 = { group = "org.springframework.boot", name = "spring-boot-dependencies", version = "3.3.13" }
 spring-core-61 = { group = "org.springframework", name = "spring-core", version = "6.1.21" }
 spring-core-62 = { group = "org.springframework", name = "spring-core", version = "6.2.8" }
-spring-core-70 = { group = "org.springframework", name = "spring-core", version = "7.0.0-M6" }
+spring-core-70 = { group = "org.springframework", name = "spring-core", version = "7.0.0-M5" }


### PR DESCRIPTION
M6 does not build as it requires pre-installed openjdk-24 which is not backported to noble.