### PR TITLE
feat: use openjdk snap to build spring framework 7.0

### DIFF
--- a/content-snap-generator/src/main/java/com/canonical/devpackspring/content/App.java
+++ b/content-snap-generator/src/main/java/com/canonical/devpackspring/content/App.java
@@ -80,10 +80,13 @@ public final class App {
                 }
                 var snap = (Map<String, String>) snaps.get(name);
                 var snapJDK = ((Map<String, List<String>>) snaps.get(name)).getOrDefault("build-jdk", Arrays.asList("openjdk-17-jdk-headless"));
+                var buildSnaps = ((Map<String, List<String>>) snaps.get(name)).getOrDefault("build-snap", List.of());
                 TomlTable versionEntry = libraries.getTableOrEmpty(snap.get("version"));
                 snapList.add(new ContentSnap(snap.get("name"), versionEntry.getString("version"), snap.get("summary"),
                         snap.get("description"), snap.get("upstream"), snap.get("license"),
+                        snap.getOrDefault("setup-command", ""),
                         snapJDK,
+                        buildSnaps,
                         snap.getOrDefault("extra-command", "")));
             }
         }
@@ -183,7 +186,7 @@ public final class App {
     }
 
     record ContentSnap(String name, String version, String summary, String description, String upstream, String license,
-                       List<String> build_jdk, String extra_command) {
+                       String setup_command, List<String> build_jdk, List<String> build_snap, String extra_command) {
 
         public Map<String, String> getReplacements() {
 
@@ -195,7 +198,9 @@ public final class App {
             map.put("upstream", this.upstream);
             map.put("license", this.license);
             map.put("build-jdk", formatList(this.build_jdk));
+            map.put("build-snap", formatList(this.build_snap));
             map.put("extra-command", this.extra_command);
+            map.put("setup-command", this.setup_command);
             return map;
         }
 

--- a/content-snaps/common/snap/snapcraft.yaml.template
+++ b/content-snaps/common/snap/snapcraft.yaml.template
@@ -29,13 +29,13 @@ parts:
     source-type: git
     source-tag: v${version}
     build-packages: ${build-jdk}
+    build-snaps: ${build-snap}
     override-build: |
+      ${setup-command}
       echo 127.0.0.1 $(hostname) >> /etc/hosts
       mkdir -p $HOME/.gradle
       echo 'systemProp.user.name=spring-builds+github' >> $HOME/.gradle/gradle.properties
       echo 'systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false' >> $HOME/.gradle/gradle.properties
       echo 'org.gradle.daemon=false' >> $HOME/.gradle/gradle.properties
       echo 'org.gradle.daemon=4' >> $HOME/.gradle/gradle.properties
-      # do not hardcode toolchain vendor
-      find . -name JavaConventions.java -exec sed -i 's/toolchain.getVendor().set(JvmVendorSpec.BELLSOFT);/System.out.println(JvmVendorSpec.BELLSOFT);/g' {} \;
       ./gradlew -PdeploymentRepository=$CRAFT_PART_INSTALL/maven-repo build publishAllPublicationsToDeploymentRepository ${extra-command}

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -61,7 +61,7 @@ content-snaps:
       Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
     license: Apache-2.0
     lts: true
-    extra-command: -x :framework-docs:compileJava -x :framework-api:javadoc -x :spring-webmvc:test
+    extra-command: -x :framework-docs:compileJava -x :framework-api:javadoc -x :spring-webmvc:test # yamllint disable-line rule:line-length
     setup-command: export JAVA_HOME=/snap/openjdk/current/jdk
 
   content-for-spring-framework-62:

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -61,7 +61,7 @@ content-snaps:
       Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
     license: Apache-2.0
     lts: true
-    extra-command: -x :framework-api:javadoc
+    extra-command: -x :framework-docs:compileJava -x :framework-api:javadoc -x :spring-webmvc:test
     setup-command: export JAVA_HOME=/snap/openjdk/current/jdk
 
   content-for-spring-framework-62:

--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -53,7 +53,8 @@ content-snaps:
     mount: /maven-repo
     oss-eol: n/a
     name: content-for-spring-framework-70
-    build-jdk: ["openjdk-21-jdk"]
+    build-jdk: []
+    build-snap: ["openjdk"]
     summary: Rebuild of Spring® Framework sources v7.0.x
     description: |
       Rebuild of Spring® Framework sources v7.0.x.
@@ -61,6 +62,7 @@ content-snaps:
     license: Apache-2.0
     lts: true
     extra-command: -x :framework-api:javadoc
+    setup-command: export JAVA_HOME=/snap/openjdk/current/jdk
 
   content-for-spring-framework-62:
     upstream: https://github.com/spring-projects/spring-framework


### PR DESCRIPTION
Spring Framework uses openjdk 24 features.  Snap build base is noble, where we do not have openjdk 24.  Use openjdk snap to install the build jdk. 

Exclude projects that fail to build 

