### PR TITLE
chore: disable spring-framework 7.0 build

### DIFF
--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -46,23 +46,27 @@ content-snaps:
     lts: false
 
 
-  content-for-spring-framework-70:
-    upstream: https://github.com/spring-projects/spring-framework
-    version: spring-core-70
-    channel: latest/edge
-    mount: /maven-repo
-    oss-eol: n/a
-    name: content-for-spring-framework-70
-    build-jdk: []
-    build-snap: ["openjdk"]
-    summary: Rebuild of Spring® Framework sources v7.0.x
-    description: |
-      Rebuild of Spring® Framework sources v7.0.x.
-      Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
-    license: Apache-2.0
-    lts: true
-    extra-command: -x :framework-docs:compileJava -x :framework-api:javadoc -x :spring-webmvc:test # yamllint disable-line rule:line-length
-    setup-command: export JAVA_HOME=/snap/openjdk/current/jdk
+# commented out spring framework 7 snapshot until openjdk-25 is
+# supported
+#   content-for-spring-framework-70:
+#    upstream: https://github.com/spring-projects/spring-framework
+#    version: spring-core-70
+#    channel: latest/edge
+#    mount: /maven-repo
+#    oss-eol: n/a
+#    name: content-for-spring-framework-70
+#    build-jdk: []
+#    build-snap: ["openjdk"]
+#    summary: Rebuild of Spring® Framework sources v7.0.x
+#    description: |
+#      Rebuild of Spring® Framework sources v7.0.x.
+#      Spring is a trademark of Broadcom Inc. and/or its subsidiaries.
+#    license: Apache-2.0
+#    lts: true
+#    extra-command: -x :framework-docs:compileJava -x \
+#            :framework-api:javadoc -x :spring-webmvc:test \
+#             # yamllint disable-line rule:line-length
+#    setup-command: export JAVA_HOME=/snap/openjdk/current/jdk
 
   content-for-spring-framework-62:
     upstream: https://github.com/spring-projects/spring-framework


### PR DESCRIPTION
Spring Framework 7.0 builds against obsolete OpenJDK 24. Disable build until it is migrated to Gradle 9/OpenJDK 25.