### PR TITLE
Bump version to 1.3.4 and update source tag (0.13.4)

### DIFF
--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '1.3.3'
+version: '1.3.4'
 license: Apache-2.0
 summary: Development tools for Spring® projects
 title: Development tools for Spring® projects
@@ -34,7 +34,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/devpack-for-spring-cli
     source-type: git
-    source-tag: 0.13.3
+    source-tag: 0.13.4
     stage-packages:
       - bash_bins
       - openjdk-25-jdk-headless_standard


### PR DESCRIPTION
- This fixes Groovy parsing error in multi-line strings