### PR TITLE
chore: release 1.4.0

### DIFF
--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '1.3.6'
+version: '1.4.0'
 license: Apache-2.0
 summary: Development tools for Spring® projects
 title: Development tools for Spring® projects
@@ -34,7 +34,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/devpack-for-spring-cli
     source-type: git
-    source-tag: 0.13.6
+    source-tag: 0.14.0
     stage-packages:
       - bash_bins
       - openjdk-25-jdk-headless_standard


### PR DESCRIPTION
This MR releases 1.4.0 (using devpack-for-spring-cli 0.14). 

This release changes command line options and migrates the CLI to Spring Shell 4.0.