### PR TITLE
fix: add content-for-spring-ai-20 snapcraft template

### DIFF
--- a/content-snaps/content-for-spring-ai-20/snap/snapcraft.yaml.template
+++ b/content-snaps/content-for-spring-ai-20/snap/snapcraft.yaml.template
@@ -1,0 +1,36 @@
+name: ${name}
+base: bare
+build-base: core24
+version: '${version}'
+summary: ${summary}
+license: ${license}
+description: |
+${description}
+
+grade: stable
+confinement: strict
+
+platforms:
+  amd64:
+  arm64:
+
+slots:
+  ${name}:
+    interface: content
+    content: ${name}
+    source:
+      read:
+        - $SNAP
+
+parts:
+  content:
+    plugin: nil
+    source: ${upstream}
+    source-type: git
+    source-tag: v${version}
+    build-packages: ${build-jdk}
+    build-snaps: ${build-snap}
+    override-build: |
+      ${setup-command}
+      echo 127.0.0.1 $(hostname) >> /etc/hosts
+      ./mvnw -DskipTests -DaltDeploymentRepository=local-repo::default::file://$CRAFT_PART_INSTALL/maven-repo clean deploy


### PR DESCRIPTION
Add missing file for content-spring-ai-20, as Spring AI uses maven to build projects.