### PR TITLE
chore: fix spread tests for 1.4.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Run content snap generator
         id: gen-content
         run: |
+          unset JAVA_HOME
           sudo apt-get update && sudo apt-get install -y make maven openjdk-25-jdk-headless
           make prepare
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64, amd64]
-    runs-on: self-hosted-linux-${{ matrix.arch }}-noble-large
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         id: checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run content snap generator
         id: gen-content
         run: |
-          sudo apt-get update && sudo apt-get install -y make maven openjdk-21-jdk-headless
+          sudo apt-get update && sudo apt-get install -y make maven openjdk-25-jdk-headless
           make prepare
 
       - name: Build devpack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,11 +21,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         id: checkout
-
+      - uses: actions/setup-java@v5
+        with:
+            distribution: 'temurin'
+            java-version: '21'
+            cache: 'maven'
       - name: Run content snap generator
         id: gen-content
         run: |
-          unset JAVA_HOME
           sudo apt-get update && sudo apt-get install -y make maven openjdk-25-jdk-headless
           make prepare
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ all: build
 build: $(SNAP_DIRS)
 
 prepare:
+	echo "Java Home: $$JAVA_HOME"
+	echo "Java version $(shell java --version)"
 	(cd content-snap-generator && mvn package)
 	java -jar content-snap-generator/target/content-snap-generator-1.0-shaded.jar \
 		-m devpack-for-spring-manifest/supported.yaml \

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
         --enable-native-access=ALL-UNNAMED \
         -Dspring.aot.enabled=true \
         -Dio.netty.noUnsafe=true \
-        -cp "cli/devpack-for-spring-cli.jar:$CLASSPATH" org.springframework.cli.DevpackForSpringCliApplication list-plugins
+        -cp "cli/devpack-for-spring-cli.jar:$CLASSPATH" org.springframework.cli.DevpackForSpringCliApplication plugins
 
       craftctl default
 

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '1.4.0'
+version: '1.4.1'
 license: Apache-2.0
 summary: Development tools for Spring® projects
 title: Development tools for Spring® projects
@@ -34,7 +34,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/devpack-for-spring-cli
     source-type: git
-    source-tag: 0.14.0
+    source-tag: 0.14.1
     stage-packages:
       - bash_bins
       - openjdk-25-jdk-headless_standard

--- a/tests/spread/install-content/task.yaml
+++ b/tests/spread/install-content/task.yaml
@@ -2,17 +2,17 @@ summary: check that devpack for spring can install content snaps
 
 execute: |
   set -ex
-  SNAPS=`devpack-for-spring snap list | grep content | awk -F'│' '{ print $3 }'`
+  SNAPS=`devpack-for-spring libraries | grep content | awk -F'│' '{ print $3 }'`
   for snap in $SNAPS; do
     # install snap
-    devpack-for-spring snap install $snap
-    devpack-for-spring snap list | grep $snap | grep '✓'
+    devpack-for-spring add-library $snap
+    devpack-for-spring libraries | grep $snap | grep '✓'
     # regenerate configuration
-    devpack-for-spring snap setup-gradle
-    devpack-for-spring snap setup-maven
+    devpack-for-spring setup-gradle
+    devpack-for-spring setup-gradle
     # remove snap
-    devpack-for-spring snap remove $snap
+    devpack-for-spring remove-library $snap
     # regenerate configuration
-    devpack-for-spring snap setup-gradle
-    devpack-for-spring snap setup-maven
+    devpack-for-spring setup-gradle
+    devpack-for-spring setup-gradle
   done

--- a/tests/spread/install-content/task.yaml
+++ b/tests/spread/install-content/task.yaml
@@ -8,11 +8,11 @@ execute: |
     devpack-for-spring add-library $snap
     devpack-for-spring libraries | grep $snap | grep '✓'
     # regenerate configuration
-    devpack-for-spring setup-gradle
-    devpack-for-spring setup-gradle
+    devpack-for-spring gradle-libraries
+    devpack-for-spring maven-libraries
     # remove snap
     devpack-for-spring remove-library $snap
     # regenerate configuration
-    devpack-for-spring setup-gradle
-    devpack-for-spring setup-gradle
+    devpack-for-spring gradle-libraries
+    devpack-for-spring maven-libraries
   done

--- a/tests/spread/plugin-gradle-groovy/task.yaml
+++ b/tests/spread/plugin-gradle-groovy/task.yaml
@@ -1,5 +1,5 @@
 summary: test build plugin functionality for gradle groovy
 execute: |
   set -ex
-  devpack-for-spring plugin checkstyle | grep -q "Plugin checkstyle is already configured."
-  devpack-for-spring plugin pmd | grep -q pmdTest
+  devpack-for-spring run checkstyle | grep -q "Plugin checkstyle is already configured."
+  devpack-for-spring run pmd | grep -q pmdTest

--- a/tests/spread/plugin-gradle-kotlin/task.yaml
+++ b/tests/spread/plugin-gradle-kotlin/task.yaml
@@ -1,5 +1,5 @@
 summary: test build plugin functionality for gradle kotlin
 execute: |
   set -ex
-  devpack-for-spring plugin checkstyle | grep -q "Plugin checkstyle is already configured."
-  devpack-for-spring plugin pmd | grep -q pmdTest
+  devpack-for-spring run checkstyle | grep -q "Plugin checkstyle is already configured."
+  devpack-for-spring run pmd | grep -q pmdTest

--- a/tests/spread/plugin-maven/task.yaml
+++ b/tests/spread/plugin-maven/task.yaml
@@ -1,5 +1,5 @@
 summary: test build plugin functionality for maven
 execute: |
   set -ex
-  devpack-for-spring plugin checkstyle | grep -q "Plugin org.apache.maven.plugins:maven-checkstyle-plugin is already configured. Using project configuration."
-  devpack-for-spring plugin pmd | grep -q "PMD version:"
+  devpack-for-spring run checkstyle | grep -q "Plugin org.apache.maven.plugins:maven-checkstyle-plugin is already configured. Using project configuration."
+  devpack-for-spring run pmd | grep -q "PMD version:"

--- a/tests/spread/project-build-gradle/task.yaml
+++ b/tests/spread/project-build-gradle/task.yaml
@@ -4,7 +4,7 @@ execute: |
   set -ex
   # use snap-provided JVM
   export PATH=$PATH:/snap/devpack-for-spring/current/usr/bin/
-  devpack-for-spring snap install content-for-spring-boot-35
+  devpack-for-spring add-library content-for-spring-boot-35
   BOOT_VERSION=`snap info  content-for-spring-boot-35 | grep "installed:" | awk -F' ' '{ print $2}'`
   devpack-for-spring boot start --path foo --project gradle-project \
    --language java --boot-version $BOOT_VERSION --group sample \

--- a/tests/spread/project-build-maven/task.yaml
+++ b/tests/spread/project-build-maven/task.yaml
@@ -4,7 +4,7 @@ execute: |
   set -ex
   # use snap-provided JVM
   export PATH=$PATH:/snap/devpack-for-spring/current/usr/bin/
-  devpack-for-spring snap install content-for-spring-boot-35
+  devpack-for-spring add-library content-for-spring-boot-35
   BOOT_VERSION=`snap info  content-for-spring-boot-35 | grep "installed:" | awk -F' ' '{ print $2}'`
   devpack-for-spring boot start --path foo --project maven-project \
    --language java --boot-version $BOOT_VERSION --group sample \


### PR DESCRIPTION
devpack-for-spring 1.4.0 contains a breaking change in the command names. 
Update spread tests to use new command names.
Use github runner to avoid soft-ban from maven central.