### PR TITLE
fix: fix Spring AI 2.0 upstream version

### DIFF
--- a/devpack-for-spring-manifest/supported.yaml
+++ b/devpack-for-spring-manifest/supported.yaml
@@ -47,7 +47,7 @@ content-snaps:
 
   content-for-spring-ai-20:
     upstream: https://github.com/spring-projects/spring-ai
-    version: spring-ai-11
+    version: spring-ai-20
     channel: latest/edge
     mount: /maven-repo
     oss-eol: n/a


### PR DESCRIPTION
Spring AI 2.0 version was  set to 1.1.8. 