### PR TITLE
chore: new release 1.4.2 (0.14.2 devpack-for-spring-cli)

### DIFF
--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '1.4.1'
+version: '1.4.2'
 license: Apache-2.0
 summary: Development tools for Spring® projects
 title: Development tools for Spring® projects
@@ -34,7 +34,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/devpack-for-spring-cli
     source-type: git
-    source-tag: 0.14.1
+    source-tag: 0.14.2
     stage-packages:
       - bash_bins
       - openjdk-25-jdk-headless_standard


### PR DESCRIPTION
This MR fixes `<command> --help ` and invalid error message for the `--file` parameter. 