### PR TITLE
feat: support http_proxy environment variables

### DIFF
--- a/devpack-for-spring/README.md
+++ b/devpack-for-spring/README.md
@@ -174,7 +174,7 @@ You can set the following optional environment variables:
 
 - `SPRING_CLI_SETUP_COMMANDS_CONFIGURATION` - path configuration file for `devpack-for-spring setup`,
    defaults to `/snap/devpack-for-spring/current/setup-configuration.yaml`.
-- `DEVPACK_FOR_SPRING_KEYSTORE` - path to the Java keystore to use for HTTPS connections, defaults to `/etc/ssl/certs/java/cacerts` if openjdk is installed on the host, otherwise it uses the embedded one.
+- `DEVPACK_FOR_SPRING_KEYSTORE` - path to the Java trust store to use for HTTPS connections, defaults to `/etc/ssl/certs/java/cacerts` if that file exists on the host, otherwise no trust store override is passed and the embedded JVM's default trust store is used.
 - `DEVPACK_FOR_SPRING_DEBUG_FLAG` - disables AOT cache, injects JVM arguments into `devpack-for-spring` command.
 - `DEVPACK_FOR_SPRING_JAVA_HOME` - alternative JAVA_HOME (minimum Java 25).
 
@@ -183,7 +183,7 @@ You can set the following optional environment variables:
 `devpack-for-spring` supports environment variables `http_proxy`, `https_proxy` and `no_proxy` with the
 following limitations:
 - `no_proxy` - CIDR entries are not supported, '*' wildcard is ignored.
-- HTTPS proxies that use non-standard certificates require an up-to-date Java keystore - install any openjdk package and update the host's Java keystore:
+- HTTPS proxies that use non-standard certificates require an up-to-date Java trust store - install any openjdk package and update the host's Java keystore:
 ```
 $ apt install default-jre-headless
 $ update-ca-certificates -f

--- a/devpack-for-spring/README.md
+++ b/devpack-for-spring/README.md
@@ -168,6 +168,27 @@ $ devpack-for-spring run rockcraft push-rock
 
 The image is tagged `<your-project-name>:latest`,`<your-project-name>:<your-project-version>`.
 
+## Environment variables
+
+You can set the following optional environment variables:
+
+- `SPRING_CLI_SETUP_COMMANDS_CONFIGURATION` - path configuration file for `devpack-for-spring setup`,
+   defaults to `/snap/devpack-for-spring/current/setup-configuration.yaml`.
+- `DEVPACK_FOR_SPRING_KEYSTORE` - path to the Java keystore to use for HTTPS connections, defaults to `/etc/ssl/certs/java/cacerts` if openjdk is installed on the host, otherwise it uses the embedded one.
+- `DEVPACK_FOR_SPRING_DEBUG_FLAG` - disables AOT cache, injects JVM arguments into `devpack-for-spring` command.
+- `DEVPACK_FOR_SPRING_JAVA_HOME` - alternative JAVA_HOME (minimum Java 25).
+
+## Proxy support
+
+`devpack-for-spring` supports environment variables `http_proxy`, `https_proxy` and `no_proxy` with the
+following limitations:
+- `no_proxy` - CIDR entries are not supported, '*' wildcard is ignored.
+- HTTPS proxies that use non-standard certificates require an up-to-date Java keystore - install any openjdk package and update the host's Java keystore:
+```
+$ apt install default-jre-headless
+$ update-ca-certificates -f
+```
+
 ## Limitations/Known issues
 
 - The 'run' command for Gradle projects supports only Gradle 8.4 and up.

--- a/devpack-for-spring/README.md
+++ b/devpack-for-spring/README.md
@@ -183,7 +183,7 @@ You can set the following optional environment variables:
 `devpack-for-spring` supports environment variables `http_proxy`, `https_proxy` and `no_proxy` with the
 following limitations:
 - `no_proxy` - CIDR entries are not supported, '*' wildcard is ignored.
-- HTTPS proxies that use non-standard certificates require an up-to-date Java trust store - install any openjdk package and update the host's Java keystore:
+- HTTPS proxies that use non-standard certificates require an up-to-date Java trust store - install any openjdk package and update the host's Java trust store:
 ```
 $ apt install default-jre-headless
 $ update-ca-certificates -f

--- a/devpack-for-spring/cli.sh
+++ b/devpack-for-spring/cli.sh
@@ -2,6 +2,7 @@
 set -e
 export SPRING_CLI_SETUP_COMMANDS_CONFIGURATION=${SPRING_CLI_SETUP_COMMANDS_CONFIGURATION:-/snap/devpack-for-spring/current/setup-configuration.yaml}
 
+DEFAULT_KEYSTORE=""
 if [ -f /etc/ssl/certs/java/cacerts ] || [ -n "$DEVPACK_FOR_SPRING_KEYSTORE" ]; then
   DEFAULT_KEYSTORE="-Djavax.net.ssl.trustStore=${DEVPACK_FOR_SPRING_KEYSTORE:-/etc/ssl/certs/java/cacerts}"
 fi
@@ -16,7 +17,7 @@ if [ -n "$DEVPACK_FOR_SPRING_DEBUG_FLAG" ]; then
     set -ex
 fi
 
-JAVA="${DEVPACK_FOR_SPRING_JAVA_HOME:-$SNAP/usr/}/bin/java"
+JAVA="${DEVPACK_FOR_SPRING_JAVA_HOME:-$SNAP/usr}/bin/java"
 
 "$JAVA" \
     $DEFAULT_KEYSTORE \

--- a/devpack-for-spring/cli.sh
+++ b/devpack-for-spring/cli.sh
@@ -2,6 +2,10 @@
 set -e
 export SPRING_CLI_SETUP_COMMANDS_CONFIGURATION=${SPRING_CLI_SETUP_COMMANDS_CONFIGURATION:-/snap/devpack-for-spring/current/setup-configuration.yaml}
 
+if [ -f /etc/ssl/certs/java/cacerts ] || [ -n "$DEVPACK_FOR_SPRING_KEYSTORE" ]; then
+  DEFAULT_KEYSTORE="-Djavax.net.ssl.trustStore=${DEVPACK_FOR_SPRING_KEYSTORE:-/etc/ssl/certs/java/cacerts}"
+fi
+
 NATIVE_ACCESS="--sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED"
 AOT_PATH="$SNAP/cli/devpack-for-spring-cli.aot"
 AOT_FLAG="-XX:AOTCache=$AOT_PATH -XX:AOTMode=on -Xlog:aot=error"
@@ -12,7 +16,10 @@ if [ -n "$DEVPACK_FOR_SPRING_DEBUG_FLAG" ]; then
     set -ex
 fi
 
-"$SNAP/usr/bin/java" \
+JAVA="${DEVPACK_FOR_SPRING_JAVA_HOME:-$SNAP/usr/}/bin/java"
+
+"$JAVA" \
+    $DEFAULT_KEYSTORE \
     $DEVPACK_FOR_SPRING_DEBUG_FLAG \
     $AOT_FLAG \
     -Dspring.aot.enabled=true \

--- a/devpack-for-spring/snap/snapcraft.yaml
+++ b/devpack-for-spring/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: devpack-for-spring
 base: bare
 build-base: core24
-version: '1.4.2'
+version: '1.4.3'
 license: Apache-2.0
 summary: Development tools for Spring® projects
 title: Development tools for Spring® projects
@@ -34,7 +34,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/devpack-for-spring-cli
     source-type: git
-    source-tag: 0.14.2
+    source-tag: 0.14.3
     stage-packages:
       - bash_bins
       - openjdk-25-jdk-headless_standard

--- a/tests/spread/boot-start-proxy/proxy.sh
+++ b/tests/spread/boot-start-proxy/proxy.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -e
+
+apt-get update && apt-get install -y squid-openssl openssl iptables ca-certificates-java
+
+echo "=== 2. Generating SSL Certificate for HTTPS Interception ==="
+
+CERT_DIR="/etc/squid/certs"
+mkdir -p "$CERT_DIR"
+
+if [ ! -f "$CERT_DIR/squid.pem" ]; then
+    openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 \
+      -subj "/C=US/ST=State/L=City/O=Testing/CN=SquidCA" \
+      -keyout "$CERT_DIR/squid.key" -out "$CERT_DIR/squid.crt"
+
+    # Combine them for Squid
+    cat "$CERT_DIR/squid.crt" "$CERT_DIR/squid.key" > "$CERT_DIR/squid.pem"
+    chmod 400 "$CERT_DIR/squid.pem"
+    chown -R proxy:proxy "$CERT_DIR"
+fi
+
+rm -rf /var/lib/squid/ssl_db
+mkdir -p /var/lib/squid
+chown -R proxy:proxy /var/lib/squid
+/usr/lib/squid/security_file_certgen -c -s /var/lib/squid/ssl_db -M 4MB
+
+echo "=== 3. Configuring Squid for HTTP & HTTPS (SSL-Bump) ==="
+SQUID_CONF="/etc/squid/squid.conf"
+
+cat << 'EOF' > "$SQUID_CONF"
+# Define local network access
+acl localnet src 0.0.0.1-0.255.255.255
+acl localnet src 10.0.0.0/8
+acl localnet src 172.16.0.0/12
+acl localnet src 192.168.0.0/16
+acl localnet src fc00::/7
+acl localnet src fe80::/10
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 443		# https
+
+http_access deny !Safe_ports
+http_access allow localhost manager
+http_access deny manager
+http_access allow localnet
+http_access allow localhost
+http_access deny all
+
+# --- SSL-Bump Configuration ---
+# Listen on 3128 for standard explicit HTTP/HTTPS proxying with SSL-Bump
+http_port 3128 ssl-bump cert=/etc/squid/certs/squid.pem generate-host-certificates=on dynamic_cert_mem_cache_size=4MB
+
+# Configure SSL-Bump steps
+# step1: Discover client SNI (Server Name Indication)
+# peek: Look at the SNI without establishing a connection yet
+# bump: Intercept and establish a secure connection using a generated cert
+acl step1 at_step SslBump1
+ssl_bump peek step1
+ssl_bump bump all
+
+# SSL database helper program
+sslcrtd_program /usr/lib/squid/security_file_certgen -s /var/lib/squid/ssl_db -M 4MB
+
+coredump_dir /var/spool/squid
+EOF
+
+# Restart Squid to apply SSL-Bump configuration
+systemctl restart squid
+
+echo "=== 4. Setting Environment Variables & Trusting the CA ==="
+# Applications using the proxy must trust Squid's self-signed CA certificate,
+# otherwise HTTPS requests will fail with "SSL Certificate Untrusted" errors.
+cp "$CERT_DIR/squid.crt" /usr/local/share/ca-certificates/squid-ca.crt
+update-ca-certificates -f
+
+# Set up global proxy variables
+cat << 'EOF' > /etc/environment
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+http_proxy="http://127.0.0.1:3128/"
+https_proxy="http://127.0.0.1:3128/"
+HTTP_PROXY="http://127.0.0.1:3128/"
+HTTPS_PROXY="http://127.0.0.1:3128/"
+no_proxy="localhost,127.0.0.1"
+NO_PROXY="localhost,127.0.0.1"
+EOF
+
+# Export to current shell session
+export http_proxy="http://127.0.0.1:3128/"
+export https_proxy="http://127.0.0.1:3128/"
+
+echo "=== 5. Hardening Firewall (Blocking direct Outgoing 80/443) ==="
+# Clear existing rules for a clean state during testing
+iptables -F OUTPUT
+
+# 1. Allow local loopback traffic
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# 2. Allow the 'proxy' user (Squid) to actually reach the internet over 80 and 443
+iptables -A OUTPUT -p tcp -m owner --uid-owner proxy --dport 80 -j ACCEPT
+iptables -A OUTPUT -p tcp -m owner --uid-owner proxy --dport 443 -j ACCEPT
+
+# 3. REJECT all other direct outgoing HTTP (80) and HTTPS (443) traffic
+iptables -A OUTPUT -p tcp --dport 80 -j REJECT --reject-with icmp-port-unreachable
+iptables -A OUTPUT -p tcp --dport 443 -j REJECT --reject-with icmp-port-unreachable
+
+echo "=== Configuration Complete ==="
+echo "Testing DIRECT HTTPS connection (Should Fail):"
+curl -I --noproxy '*' https://www.google.com || echo "Successfully blocked direct access."
+
+echo "-----------------------------"
+
+echo "Testing PROXIED HTTPS connection (Should Succeed):"
+curl -I https://www.google.com
+
+echo "=== Initialize Spring Boot project ==="
+devpack-for-spring version
+devpack-for-spring boot start --path foo --project gradle-project \
+    --language java --boot-version 4.1.0 --group sample \
+    --artifact sample --name sample --description sample \
+    --package-name sample --packaging jar \
+    --java-version 17 --version 1

--- a/tests/spread/boot-start-proxy/task.yaml
+++ b/tests/spread/boot-start-proxy/task.yaml
@@ -1,0 +1,5 @@
+summary: check that devpack for spring can handle proxy access
+
+execute: |
+  set -ex
+  bash proxy.sh


### PR DESCRIPTION

>> Claude Sonnet 4.6:

## Review: `boot_proxy` branch

**Scope reviewed:** commits `25182e7` (feat: add proxy support), `e65b8d0`/`16e0cef` (docs), `7c98cca` (fix: cli.sh typos) — i.e., `devpack-for-spring/cli.sh`, `devpack-for-spring/snap/snapcraft.yaml`, and `devpack-for-spring/README.md`. `tests/spread/boot-start-proxy/proxy.sh` excluded per your instructions.

**Summary:** The change is small and well-targeted. It delegates actual proxy-env-var handling (`http_proxy`/`https_proxy`/`no_proxy`) to `devpack-for-spring-cli` (bumped to source-tag `0.14.3`, which does add `ProxyConfiguration`/system-proxy support — verified in that repo). The snap wrapper (`cli.sh`) only needs to add JVM trust-store support so HTTPS proxies with custom CA certs work, plus a `DEVPACK_FOR_SPRING_JAVA_HOME` override. Logic checks out:

- `DEFAULT_KEYSTORE` is correctly initialized to `""` before the conditional (the typo-fix commit correctly added this — without it, under `set -e`/unbound-safe patterns it was previously implicitly empty only because the `if` might not run, but declaring it explicitly is safer and avoids leaking a stale value across invocations in edge cases).
- Trust store flag only applied when `/etc/ssl/certs/java/cacerts` exists or `DEVPACK_FOR_SPRING_KEYSTORE` is explicitly set — sensible default, avoids passing a bogus `-Djavax.net.ssl.trustStore` when there's no host keystore.
- `JAVA="${DEVPACK_FOR_SPRING_JAVA_HOME:-$SNAP/usr}/bin/java"` — the typo fix (removing trailing slash from the default) is correct and matches the previous `"$SNAP/usr/bin/java"` behavior exactly.
- Unquoted `$DEFAULT_KEYSTORE` expansion (shellcheck SC2086) is consistent with the pre-existing style for `$AOT_FLAG`/`$NATIVE_ACCESS`/`$DEVPACK_FOR_SPRING_DEBUG_FLAG` in this file, so not a new regression — it's intentional so multi-flag variables split into separate args.
- `snapcraft.yaml` version/source-tag bump (`1.4.2`→`1.4.3`, `0.14.2`→`0.14.3`) correctly tracks the corresponding CLI proxy feature commit (`feat: use system proxy settings for http client (#237)`).
- README additions are accurate and match actual behavior. Only a minor nit: it uses "trust store" and "keystore" interchangeably in the same bullet (`"Java trust store ... update the host's Java keystore"`) — cosmetic, not blocking.

**No functional issues found.** The one very minor polish item is the trust-store/keystore terminology mix in the README; everything else is correct and consistent with the underlying CLI's proxy implementation.